### PR TITLE
Fixed `Host` header regression. Fixed #4

### DIFF
--- a/lib/eight-track.js
+++ b/lib/eight-track.js
@@ -115,17 +115,38 @@ function eightTrackCreator(options) {
           return EightTrack.sendResponse(internalRes, responseInfo);
         }
 
-        // Forward the original request to the new server
+        // Prepate the URL for headers logic
         var internalUrl = url.parse(internalReq.url);
+        var _url = _.defaults({
+          path: internalUrl.path
+        }, externalUrl);
+
+        // Set up headers
+        var headers = internalReq.headers;
+
+        // If there is a host, use our new host for the request
+        if (headers.host) {
+          headers = _.clone(headers);
+          delete headers.host;
+
+          // Logic taken from https://github.com/mikeal/request/blob/v2.30.1/request.js#L193-L202
+          headers.host = _url.hostname;
+          if (_url.port) {
+            if ( !(_url.port === 80 && _url.protocol === 'http:') &&
+                 !(_url.port === 443 && _url.protocol === 'https:') ) {
+              headers.host += ':' + _url.port;
+            }
+          }
+        }
+
+        // Forward the original request to the new server
         var externalReq = request({
           // DEV: Missing `httpVersion`
-          headers: internalReq.headers,
+          headers: headers,
           // DEV: request does not support `trailers`
           trailers: internalReq.trailers,
           method: internalReq.method,
-          url: _.defaults({
-            path: internalUrl.path
-          }, externalUrl),
+          url: _url,
           body: internalBody
         });
 

--- a/test/eight-track_test.js
+++ b/test/eight-track_test.js
@@ -288,3 +288,54 @@ describe('An `eight-track` loading from a saved file', function () {
     });
   });
 });
+
+// DEV: Regression test for https://github.com/uber/eight-track/issues/4
+describe('A server that echoes HTTP headers', function () {
+  serverUtils.run(1337, function (req, res) {
+    res.send(req.headers);
+  });
+  serverUtils.runEightServer(1338, {
+    fixtureDir: __dirname + '/actual-files/headers',
+    url: 'http://localhost:1337'
+  });
+
+  describe('when requested with a `Host` header', function () {
+    httpUtils.save({
+      headers: {
+        host: '127.0.0.1:9001'
+      },
+      url: 'http://localhost:1338/'
+    });
+
+    it('replies with a proper `Host` header', function () {
+      expect(this.err).to.equal(null);
+      expect(this.res.statusCode).to.equal(200);
+      expect(JSON.parse(this.body)).to.have.property('host', 'localhost:1337');
+    });
+
+    it('does not affect the original header', function () {
+      expect(this.res.req._headers).to.have.property('host', '127.0.0.1:9001');
+    });
+
+    describe('when requested again', function () {
+      httpUtils.save({
+        headers: {
+          host: '127.0.0.1:9001'
+        },
+        url: 'http://localhost:1338/'
+      });
+
+      it('has the proper `Host` header', function () {
+        expect(JSON.parse(this.body)).to.have.property('host', 'localhost:1337');
+      });
+
+      it('does not affect the original header', function () {
+        expect(this.res.req._headers).to.have.property('host', '127.0.0.1:9001');
+      });
+
+      it('does not double request', function () {
+        expect(this.requests[1337]).to.have.property('length', 1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
As described in #4, forwarded requests should be creating a new `Host` header if provided. This PR patches that.

In this PR:
- Added regression test for #4 
- Added fixes against regression

/cc @mlmorg @zheller 
