### PR TITLE
Refactor eight-track to use Connection classes for incoming/outgoing requests/responses and fs-store for interacting with storage abstraction

### DIFF
--- a/lib/connections.js
+++ b/lib/connections.js
@@ -1,0 +1,85 @@
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+var _ = require('underscore');
+var async = require('async');
+var concat = require('concat-stream');
+
+// Create generic connection to inherit from
+function GenericConnection(req, res) {
+  // Inherit from event emitter
+  EventEmitter.call(this);
+
+  // Save the req and res for later
+  this.req = req;
+  this.res = res;
+}
+GenericConnection.pickMessageInfo = function (message) {
+  // DEV: Refer to http://nodejs.org/api/http.html#http_http_incomingmessage
+  return _.pick(message, 'httpVersion', 'headers', 'trailers', 'method', 'url', 'statusCode');
+};
+util.inherits(GenericConnection, EventEmitter);
+
+// Define a container for input/output of an incoming request
+function IncomingConnection(req, res) {
+  // Inherit from event emitter
+  GenericConnection.call(this, req, res);
+
+  // Collect the request body
+  var that = this;
+  req.pipe(concat(function (incomingBuff) {
+    // Save the body and emit a `loaded` event
+    // DEV: The delay is so `async.waterfall` still operates when we enter it
+    that.body = incomingBuff.toString();
+    async.setImmediate(function () {
+      that.emit('loaded');
+    });
+  }));
+}
+IncomingConnection.getRequestInfo = function (req, body) {
+  var info = GenericConnection.pickMessageInfo(req);
+  delete info.statusCode;
+  info.body = body;
+  return info;
+};
+util.inherits(IncomingConnection, GenericConnection);
+_.extend(IncomingConnection.prototype, {
+  getRequestInfo: function () {
+    return IncomingConnection.getRequestInfo(this.req, this.body);
+  }
+});
+
+// Define a container for input/output of an outgoing request
+function OutgoingConnection(req, res) {
+  // Inherit from event emitter
+  GenericConnection.call(this, req, res);
+
+  // Collect the request body
+  var that = this;
+  res.pipe(concat(function (outgoingBuff) {
+    // Save the body and emit a `loaded` event
+    that.body = outgoingBuff.toString();
+    async.setImmediate(function () {
+      that.emit('loaded');
+    });
+  }));
+}
+OutgoingConnection.getResponseInfo = function (res, body) {
+  var info = GenericConnection.pickMessageInfo(res);
+  delete info.url;
+  delete info.method;
+  info.body = body;
+  return info;
+};
+util.inherits(OutgoingConnection, GenericConnection);
+_.extend(OutgoingConnection.prototype, {
+  getResponseInfo: function () {
+    return OutgoingConnection.getResponseInfo(this.res, this.body);
+  }
+});
+
+
+module.exports = {
+  GenericConnection: GenericConnection,
+  IncomingConnection: IncomingConnection,
+  OutgoingConnection: OutgoingConnection
+};

--- a/lib/eight-track.js
+++ b/lib/eight-track.js
@@ -1,96 +1,13 @@
 var assert = require('assert');
 var crypto = require('crypto');
-var fs = require('fs');
-var path = require('path');
 var url = require('url');
 var _ = require('underscore');
-var concat = require('concat-stream');
-var mkdirp = require('mkdirp');
+var async = require('async');
 var request = require('request');
+var connections = require('./connections');
+var FsStore = require('./fs-store');
 
-function EightTrack() {
-  // this.fixtureDir is set in `eightTrack`
-}
-
-EightTrack.pickMessageInfo = function (message) {
-  // DEV: Refer to http://nodejs.org/api/http.html#http_http_incomingmessage
-  return _.pick(message, 'httpVersion', 'headers', 'trailers', 'method', 'url', 'statusCode');
-};
-EightTrack.getRequestInfo = function (req, body) {
-  var info = EightTrack.pickMessageInfo(req);
-  delete info.statusCode;
-  info.body = body;
-  return info;
-};
-EightTrack.getRequestKey = function (req, body) {
-  // Generate an object representing the request
-  var info = EightTrack.getRequestInfo(req, body);
-
-  // Stringify the info and hash it
-  var json = JSON.stringify(info);
-  var md5 = crypto.createHash('md5');
-  md5.update(json);
-  var hash = md5.digest('hex');
-
-  // Compound method, url, and hash to generate the key
-  return req.method + '_' + encodeURIComponent(req.url) + '_' + hash;
-};
-EightTrack.getResponseInfo = function (res, body) {
-  var info = EightTrack.pickMessageInfo(res);
-  delete info.url;
-  delete info.method;
-  info.body = body;
-  return info;
-};
-EightTrack.sendResponse = function (res, info) {
-  res.writeHead(info.statusCode, info.headers);
-  res.write(info.body);
-  res.end();
-};
-
-EightTrack.prototype = {
-  // DEV: We use disk as truth because while it is slow,
-  // DEV: it makes for only one location to load response from
-  getFilepath: function (key) {
-    return path.join(this.fixtureDir, key + '.json');
-  },
-  getConnection: function (key, cb) {
-    // DEV: Emulate async behavior before moving to disk
-    fs.readFile(this.getFilepath(key), function parseResponse (err, content) {
-      // If there was an error
-      if (err) {
-        // If the file was not found, send back nothing
-        if (err.code === 'ENOENT') {
-          return cb(null, null);
-        // Otherwise, send back the error
-        } else {
-          return cb(err);
-        }
-      }
-
-      // Otherwise, parse the file
-      // DEV: We use a try/catch in case the JSON is invalid
-      var connInfo;
-      try {
-        connInfo = JSON.parse(content);
-      } catch (err) {
-        return cb(err);
-      }
-      cb(null, connInfo);
-    });
-  },
-  saveConnection: function (key, connInfo, cb) {
-    var filepath = this.getFilepath(key);
-    mkdirp(path.dirname(filepath), function (err) {
-      if (err) {
-        return cb(err);
-      }
-      fs.writeFile(filepath, JSON.stringify(connInfo, null, 2), cb);
-    });
-  }
-};
-
-function eightTrackCreator(options) {
+function EightTrack(options) {
   // Assert we received the expected options
   assert(options.url, '`eight-track` expected `options.url` but did not receive it');
   assert(options.fixtureDir, '`eight-track` expected `options.fixtureDir` but did not receive it');
@@ -101,107 +18,145 @@ function eightTrackCreator(options) {
     externalUrl = url.parse(externalUrl);
   }
 
-  // Define a middleware to handle requests `(req, res)`
-  function eightTrack(internalReq, internalRes) {
-    // Create reference similar to `this` to encourage OOP thought
-    var that = eightTrack;
-    that.fixtureDir = options.fixtureDir;
+  // Save externalUrl and fixtureDir for later
+  this.externalUrl = externalUrl;
+  this.store = new FsStore({
+    directory: options.fixtureDir
+  });
+}
 
-    // Collect the body
-    // DEV: If we ever go even deeper, consider moving to async.waterfall
-    internalReq.pipe(concat(function (internalBuff) {
-      // Generate a key based on the internal request and body
-      var internalBody = internalBuff.toString();
-      var requestKey = EightTrack.getRequestKey(internalReq, internalBody);
+EightTrack.getConnectionKey = function (conn) {
+  // Generate an object representing the request
+  var info = conn.getRequestInfo();
 
-      // If there is a request that already exists
-      that.getConnection(requestKey, function handleGetRes (err, connInfo) {
-        // If there was an error, emit it
-        if (err) {
-          return internalReq.emit('error', err);
+  // Stringify the info and hash it
+  var json = JSON.stringify(info);
+  var md5 = crypto.createHash('md5');
+  md5.update(json);
+  var hash = md5.digest('hex');
+
+  // Compound method, url, and hash to generate the key
+  return info.method + '_' + encodeURIComponent(info.url) + '_' + hash;
+};
+EightTrack.sendResponse = function (res, info) {
+  res.writeHead(info.statusCode, info.headers);
+  res.write(info.body);
+  res.end();
+};
+
+EightTrack.prototype = {
+  getConnection: function (key, cb) {
+    this.store.get(key, cb);
+  },
+  saveConnection: function (key, connInfo, cb) {
+    this.store.set(key, connInfo, cb);
+  },
+
+  createExternalRequest: function (internalConn) {
+    // Prepate the URL for headers logic
+    var internalReq = internalConn.req;
+    var internalUrl = url.parse(internalReq.url);
+    var _url = _.defaults({
+      path: internalUrl.path
+    }, this.externalUrl);
+
+    // Set up headers
+    var headers = internalReq.headers;
+
+    // If there is a host, use our new host for the request
+    if (headers.host) {
+      headers = _.clone(headers);
+      delete headers.host;
+
+      // Logic taken from https://github.com/mikeal/request/blob/v2.30.1/request.js#L193-L202
+      headers.host = _url.hostname;
+      if (_url.port) {
+        if ( !(_url.port === 80 && _url.protocol === 'http:') &&
+             !(_url.port === 443 && _url.protocol === 'https:') ) {
+          headers.host += ':' + _url.port;
         }
+      }
+    }
 
+    // Forward the original request to the new server
+    var externalReq = request({
+      // DEV: Missing `httpVersion`
+      headers: headers,
+      // DEV: request does not support `trailers`
+      trailers: internalReq.trailers,
+      method: internalReq.method,
+      url: _url,
+      body: internalConn.body
+    });
+    return externalReq;
+  },
+
+  handleConnection: function (internalReq, internalRes) {
+    // Create a connection to pass around between methods
+    // DEV: This cannot be placed inside the waterfall since in 0.8, we miss data + end events
+    var incomingConn = new connections.IncomingConnection(internalReq, internalRes);
+    var requestKey, externalConn, connInfo;
+
+    var that = this;
+    async.waterfall([
+      function loadIncomingBody (cb) {
+        incomingConn.on('loaded', cb);
+      },
+      function findSavedConnection (cb) {
+        requestKey = EightTrack.getConnectionKey(incomingConn);
+        that.getConnection(requestKey, cb);
+      },
+      function createExternalReq (connInfo, cb) {
         // If we successfully found the info, reply with it
         if (connInfo) {
           return EightTrack.sendResponse(internalRes, connInfo.response);
         }
 
-        // Prepate the URL for headers logic
-        var internalUrl = url.parse(internalReq.url);
-        var _url = _.defaults({
-          path: internalUrl.path
-        }, externalUrl);
-
-        // Set up headers
-        var headers = internalReq.headers;
-
-        // If there is a host, use our new host for the request
-        if (headers.host) {
-          headers = _.clone(headers);
-          delete headers.host;
-
-          // Logic taken from https://github.com/mikeal/request/blob/v2.30.1/request.js#L193-L202
-          headers.host = _url.hostname;
-          if (_url.port) {
-            if ( !(_url.port === 80 && _url.protocol === 'http:') &&
-                 !(_url.port === 443 && _url.protocol === 'https:') ) {
-              headers.host += ':' + _url.port;
-            }
-          }
-        }
-
         // Forward the original request to the new server
-        var externalReq = request({
-          // DEV: Missing `httpVersion`
-          headers: headers,
-          // DEV: request does not support `trailers`
-          trailers: internalReq.trailers,
-          method: internalReq.method,
-          url: _url,
-          body: internalBody
-        });
+        var externalReq = that.createExternalRequest(incomingConn);
 
-        // If there is an error, forward it
-        externalReq.on('error', function handleReqError (err) {
-          internalReq.emit('error', err);
-        });
-
-        // When we receive a response
+        // When we receive a response, load the response body
+        externalReq.on('error', cb);
         externalReq.on('response', function handleRes (externalRes) {
-          // Forward and save request on end
-          externalRes.pipe(concat(function handleResEnd (externalBuff) {
-            // Save the response
-            var responseInfo = EightTrack.getResponseInfo(externalRes, externalBuff.toString());
-            connInfo = {
-              request: EightTrack.getRequestInfo(internalReq, internalBody),
-              response: responseInfo
-            };
-            that.saveConnection(requestKey, connInfo, function handleSaveRes (err) {
-              // If there is an error, emit it
-              if (err) {
-                return internalReq.emit('error', err);
-              }
-
-              // Forwarding response to original
-              EightTrack.sendResponse(internalRes, responseInfo);
-            });
-          }));
+          externalConn = new connections.OutgoingConnection(externalReq, externalRes);
+          externalConn.on('loaded', cb);
         });
-      });
-    }));
+      },
+      function saveIncomingOutgoing (cb) {
+        // Save the incoming request and outgoing response info
+        connInfo = {
+          request: incomingConn.getRequestInfo(),
+          response: externalConn.getResponseInfo()
+        };
+        that.saveConnection(requestKey, connInfo, cb);
+      },
+      function forwardResponseToOriginal (cb) {
+        EightTrack.sendResponse(internalRes, connInfo.response);
+        cb(null);
+      }
+    ], function handleError (err) {
+      if (err) {
+        return internalReq.emit('error', err);
+      }
+    });
+  }
+};
+
+function middlewareCreator(options) {
+  // Create a new eight track for our middleware
+  var eightTrack = new EightTrack(options);
+
+  // Define a middleware to handle requests `(req, res)`
+  function eightTrackMiddleware(internalReq, internalRes) {
+    eightTrack.handleConnection(internalReq, internalRes);
   }
 
-  // Inherit from `EightTrack`
-  // DEV: Inspired by https://github.com/senchalabs/connect/blob/2.12.0/lib/connect.js#L64-L74
-  EightTrack.call(eightTrack);
-  _.extend(eightTrack, EightTrack.prototype);
-
   // Return the middleware
-  return eightTrack;
+  return eightTrackMiddleware;
 }
 
-// Expose class on top of eightTrackCreator
-eightTrackCreator.EightTrack = EightTrack;
+// Expose class on top of middlewareCreator
+middlewareCreator.EightTrack = EightTrack;
 
 // Expose our middleware constructor
-module.exports = eightTrackCreator;
+module.exports = middlewareCreator;

--- a/lib/fs-store.js
+++ b/lib/fs-store.js
@@ -1,0 +1,52 @@
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
+
+// DEV: I am quite confident this exists as a node module but cannot find a match =(
+
+// DEV: We use disk as truth because while it is slow,
+// DEV: it makes for only one location to load response from
+function FsStore(options) {
+  this.dir = options.directory;
+}
+FsStore.prototype = {
+  getFilepath: function (key) {
+    return path.join(this.dir, key + '.json');
+  },
+  get: function (key, cb) {
+    fs.readFile(this.getFilepath(key), function parseResponse (err, content) {
+      // If there was an error
+      if (err) {
+        // If the file was not found, send back nothing
+        if (err.code === 'ENOENT') {
+          return cb(null, null);
+        // Otherwise, send back the error
+        } else {
+          return cb(err);
+        }
+      }
+
+      // Otherwise, parse the file
+      // DEV: We use a try/catch in case the JSON is invalid
+      var data;
+      try {
+        data = JSON.parse(content);
+      } catch (err) {
+        return cb(err);
+      }
+      cb(null, data);
+    });
+  },
+  set: function (key, data, cb) {
+    var filepath = this.getFilepath(key);
+    mkdirp(path.dirname(filepath), function (err) {
+      if (err) {
+        return cb(err);
+      }
+      fs.writeFile(filepath, JSON.stringify(data, null, 2), cb);
+    });
+  }
+};
+
+// Export the store
+module.exports = FsStore;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "request": "~2.30.0",
     "underscore": "~1.5.2",
     "mkdirp": "~0.3.5",
-    "concat-stream": "~1.2.1"
+    "concat-stream": "~1.2.1",
+    "async": "~0.2.10"
   },
   "devDependencies": {
     "mocha": "~1.11.0",


### PR DESCRIPTION
After the initial composition of `eight-track`, I was unhappy with the total line length and length of the functions. This refactor establishes more abstractions (which themselves should be node modules) and cleans up the code to a more tolerable state.

In this PR:
- Create an `IncomingConnection` and `OutgoingConnection` class for different sets of `requests` and `responses`
- Break out `fs` interactions into their own storage system
  - I looked for a node module which matched our interaction but could not find one. The system is designed to save each request/response pair under its own `.json` file
- Move all middleware logic into an instance method
- Move request handling from nested callbacks to `async.waterfall`

> This PR contains changes from #8 which means #8 must be merged first.

/cc @mlmorg @Raynos 
