### PR TITLE
Added normalizeFn as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ Middleware creator for new `eightTrack's`. This *is not* a constructor.
     - fixtureDir `String` - Path to load/save HTTP responses
         - Files will be saved with the format `{{method}}_{{encodedUrl}}_{{hashOfRequestContent}}.json`
         - An example filename is `GET_%2F_658e61f2a6b2f1ae4c127e53f28dfecd.json`
+    - normalizeFn `Function` - Function to adjust `request's` save location signature
+        - If you would like to make two requests resolve from the same response file, this is how.
+        - The function signature should be `function (info)` and can either mutate the `info` or return a fresh object
+        - `info` will have the following properties
+             - httpVersion `String` - HTTP version received from `request` (e.g. `1.0`, `1.1`)
+             - headers `Object` - Headers received by `request`
+             - trailers `Object` - Trailers received by `request`
+             - method `String` - HTTP method that was used (e.g. `GET`, `POST`)
+             - url `String` - Pathname that `request` arrived from
+             - body `String` - Buffered body that was written to `request`
 
 [`url.format`]: http://nodejs.org/api/url.html#url_url_format_urlobj
 

--- a/lib/eight-track.js
+++ b/lib/eight-track.js
@@ -20,24 +20,12 @@ function EightTrack(options) {
 
   // Save externalUrl and fixtureDir for later
   this.externalUrl = externalUrl;
+  this.normalizeFn = options.normalizeFn || _.identity;
   this.store = new FsStore({
     directory: options.fixtureDir
   });
 }
 
-EightTrack.getConnectionKey = function (conn) {
-  // Generate an object representing the request
-  var info = conn.getRequestInfo();
-
-  // Stringify the info and hash it
-  var json = JSON.stringify(info);
-  var md5 = crypto.createHash('md5');
-  md5.update(json);
-  var hash = md5.digest('hex');
-
-  // Compound method, url, and hash to generate the key
-  return info.method + '_' + encodeURIComponent(info.url) + '_' + hash;
-};
 EightTrack.sendResponse = function (res, info) {
   res.writeHead(info.statusCode, info.headers);
   res.write(info.body);
@@ -45,6 +33,23 @@ EightTrack.sendResponse = function (res, info) {
 };
 
 EightTrack.prototype = {
+  getConnectionKey: function (conn) {
+    // Generate an object representing the request
+    var info = conn.getRequestInfo();
+
+    // Normalize the info
+    info = this.normalizeFn(info) || info;
+
+    // Stringify the info and hash it
+    var json = JSON.stringify(info);
+    var md5 = crypto.createHash('md5');
+    md5.update(json);
+    var hash = md5.digest('hex');
+
+    // Compound method, url, and hash to generate the key
+    return info.method + '_' + encodeURIComponent(info.url) + '_' + hash;
+  },
+
   getConnection: function (key, cb) {
     this.store.get(key, cb);
   },
@@ -103,7 +108,7 @@ EightTrack.prototype = {
         incomingConn.on('loaded', cb);
       },
       function findSavedConnection (cb) {
-        requestKey = EightTrack.getConnectionKey(incomingConn);
+        requestKey = that.getConnectionKey(incomingConn);
         that.getConnection(requestKey, cb);
       },
       function createExternalReq (connInfo, cb) {

--- a/test/eight-track_test.js
+++ b/test/eight-track_test.js
@@ -339,3 +339,60 @@ describe('A server that echoes HTTP headers', function () {
     });
   });
 });
+
+describe('A server with distinct responses', function () {
+  serverUtils.run(1337, function (req, res) {
+    express.urlencoded()(req, res, function (err) {
+      if (err) { throw err; }
+      res.send({
+        method: req.method,
+        url: req.url
+      });
+    });
+  });
+
+  describe('proxied by an eight-track that normalizes everything', function () {
+    serverUtils.runEightServer(1338, {
+      fixtureDir: __dirname + '/actual-files/headers',
+      url: 'http://localhost:1337',
+      normalizeFn: function (info) {
+        return {
+          url: '/',
+          method: 'GET'
+        };
+      }
+    });
+
+    describe('when requested', function () {
+      httpUtils.save('http://localhost:1338/?hello=there');
+
+      it('gets the expected response', function () {
+        expect(this.err).to.equal(null);
+        expect(JSON.parse(this.body)).to.deep.equal({
+          method: 'GET',
+          url: '/?hello=there'
+        });
+      });
+
+      describe('when requested with something different', function () {
+        httpUtils.save({
+          url: 'http://localhost:1338/wat',
+          method: 'POST',
+          body: 'goodbye=moon'
+        });
+
+        it('gets the original response back', function () {
+          expect(this.err).to.equal(null);
+          expect(JSON.parse(this.body)).to.deep.equal({
+            method: 'GET',
+            url: '/?hello=there'
+          });
+        });
+
+        it('does not touch the server', function () {
+          expect(this.requests[1337]).to.have.property('length', 1);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
As discussed in #9, `normalizeFn` will adjust `request` information to alter the location where we load/save a `request` from/to. In this PR:
- Add `normalizeFn` to `eight-track`
- Add test against `normalizeFn`
- Add documentation for `normalizeFn`

Fixes #9.

/cc @mlmorg 
