### PR TITLE
Truncate urls in filenames to 32 characters. Fixes #7

### DIFF
--- a/lib/eight-track.js
+++ b/lib/eight-track.js
@@ -47,7 +47,10 @@ EightTrack.prototype = {
     var hash = md5.digest('hex');
 
     // Compound method, url, and hash to generate the key
-    return info.method + '_' + encodeURIComponent(info.url) + '_' + hash;
+    // DEV: We truncate URL at 32 characters to prevent ENAMETOOLONG
+    // https://github.com/uber/eight-track/issues/7
+    var url = encodeURIComponent(info.url).substr(0, 32);
+    return info.method + '_' + url + '_' + hash;
   },
 
   getConnection: function (key, cb) {

--- a/test/eight-track_test.js
+++ b/test/eight-track_test.js
@@ -340,6 +340,30 @@ describe('A server that echoes HTTP headers', function () {
   });
 });
 
+// DEV: This is a regression test for https://github.com/uber/eight-track/issues/7
+describe('A server being proxied by `eight-track', function () {
+  serverUtils.run(1337, function (req, res) {
+    res.send('oh hai');
+  });
+  serverUtils.runEightServer(1338, {
+    fixtureDir: __dirname + '/actual-files/basic',
+    url: 'http://localhost:1337'
+  });
+
+  describe('when requested with a very long URL', function () {
+    var lotsOfCharacters = (new Array(9001)).join('a');
+    httpUtils.save('http://localhost:1338/abc/' + lotsOfCharacters + '/def');
+
+    describe('and when requested with a slightly different long URL', function () {
+      httpUtils.save('http://localhost:1338/abc/' + lotsOfCharacters + '/deg');
+
+      it('recognizes it as a separate response', function () {
+        expect(this.requests[1337]).to.have.property('length', 2);
+      });
+    });
+  });
+});
+
 describe('A server with distinct responses', function () {
   serverUtils.run(1337, function (req, res) {
     express.urlencoded()(req, res, function (err) {


### PR DESCRIPTION
As brought up in #7, we cannot currently save files that reference very long URLs. As a result, we must introduce truncation at some level. In this PR:
- Add regression test for `ENAMETOOLONG`
- Add truncation to 32 characters for URLs in filenames

/cc @mlmorg @mkadin 
