### PR TITLE
Added in performance tests and internal cache for file data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+test/actual-files/

--- a/lib/eight-track.js
+++ b/lib/eight-track.js
@@ -5,7 +5,7 @@ var _ = require('underscore');
 var async = require('async');
 var request = require('request');
 var connections = require('./connections');
-var FsStore = require('./fs-store');
+var Store = require('./store');
 
 function EightTrack(options) {
   // Assert we received the expected options
@@ -21,7 +21,7 @@ function EightTrack(options) {
   // Save externalUrl and fixtureDir for later
   this.externalUrl = externalUrl;
   this.normalizeFn = options.normalizeFn || _.identity;
-  this.store = new FsStore({
+  this.store = new Store({
     directory: options.fixtureDir
   });
 }

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,0 +1,67 @@
+var fs = require('fs');
+var path = require('path');
+var deepClone = require('clone');
+var mkdirp = require('mkdirp');
+
+// DEV: I am quite confident this exists as a node module but cannot find a match =(
+
+// DEV: We use disk as truth because while it is slow,
+// DEV: it makes for only one location to load response from
+function Store(options) {
+  this.dir = options.directory;
+  this.memoryCache = {};
+}
+Store.prototype = {
+  getFilepath: function (key) {
+    return path.join(this.dir, key + '.json');
+  },
+  get: function (key, cb) {
+    var memoryCache = this.memoryCache;
+    var cachedData = memoryCache[key];
+    if (cachedData) {
+      process.nextTick(function () {
+        // DEV: Technically, this clone is not necessary since res.send serializes
+        // However, it is good to future proof against internal changes
+        cb(null, deepClone(cachedData));
+      });
+    } else {
+      fs.readFile(this.getFilepath(key), function parseResponse (err, content) {
+        // If there was an error
+        if (err) {
+          // If the file was not found, send back nothing
+          if (err.code === 'ENOENT') {
+            return cb(null, null);
+          // Otherwise, send back the error
+          } else {
+            return cb(err);
+          }
+        }
+
+        // Otherwise, parse the file
+        // DEV: We use a try/catch in case the JSON is invalid
+        var data;
+        try {
+          data = JSON.parse(content);
+        } catch (err) {
+          return cb(err);
+        }
+        memoryCache[key] = data;
+        cb(null, deepClone(data));
+      });
+    }
+  },
+  set: function (key, data, cb) {
+    var filepath = this.getFilepath(key);
+    var that = this;
+    mkdirp(path.dirname(filepath), function (err) {
+      if (err) {
+        return cb(err);
+      }
+      that.memoryCache[key] = data;
+      fs.writeFile(filepath, JSON.stringify(data, null, 2), cb);
+    });
+  }
+};
+
+// Export the store
+module.exports = Store;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "underscore": "~1.5.2",
     "mkdirp": "~0.3.5",
     "concat-stream": "~1.2.1",
-    "async": "~0.2.10"
+    "async": "~0.2.10",
+    "clone": "~0.1.11"
   },
   "devDependencies": {
     "mocha": "~1.11.0",

--- a/test/eight-track_test.js
+++ b/test/eight-track_test.js
@@ -287,6 +287,23 @@ describe('An `eight-track` loading from a saved file', function () {
       expect(this.body).to.equal('oh hai');
     });
   });
+
+  // DEV: This is a test for verifying we don't contaminate our cache
+  describe('when a response is modified', function () {
+    httpUtils.save({
+      url: 'http://localhost:1338/'
+    });
+    before(function () {
+      this.res.body = 'hello';
+    });
+    httpUtils.save({
+      url: 'http://localhost:1338/'
+    });
+
+    it('does not impact the original data', function () {
+      expect(this.res.body).to.equal('oh hai');
+    });
+  });
 });
 
 // DEV: Regression test for https://github.com/uber/eight-track/issues/4

--- a/test/performance_test.js
+++ b/test/performance_test.js
@@ -1,0 +1,59 @@
+var fs = require('fs');
+var assert = require('assert');
+var async = require('async');
+var request = require('request');
+var eightTrack = require('../');
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+describe('A repeated request run 1000 times', function () {
+  // Create 1MB long string to load
+  var expectedStr = new Array(1e6).join('a');
+  var fixtureDir = __dirname + '/actual-files/performance';
+
+  // Prime the test data so it loads from disk
+  serverUtils.run(1337, function (req, res) {
+    res.send(expectedStr);
+  });
+  serverUtils.run(1338, eightTrack({
+    fixtureDir: fixtureDir,
+    url: 'http://localhost:1337'
+  }));
+  httpUtils.save('http://localhost:1338/');
+  before(function () {
+    assert.strictEqual(fs.readdirSync(fixtureDir).length, 1);
+  });
+
+  // Run our actual server
+  serverUtils.runEightServer(1339, {
+    fixtureDir: fixtureDir,
+    url: 'http://localhost:1337'
+  });
+
+  before(function (done) {
+    var that = this;
+    this.startTime = Date.now();
+    async.timesSeries(100, function (i, cb) {
+      // Make a request
+      request('http://localhost:1339/', function (err, res, body) {
+        // If there was an error, callback with it
+        if (err) {
+          return cb(err);
+        }
+
+        // Otherwise, assert the body and callback
+        assert.strictEqual(body, expectedStr);
+        cb();
+      });
+    }, function (err) {
+      that.endTime = Date.now();
+      done(err);
+    });
+  });
+
+  // DEV: This is Travis CI time for consistency
+  it('takes no longer than 1400ms/100 to load', function () {
+    var runTime = this.endTime - this.startTime;
+    assert(runTime < 1400, 'Expected: < 1400, Actual: ' + runTime);
+  });
+});


### PR DESCRIPTION
As mentioned in #3, we started running into performance issues. This PR introduces a cache in front of `fs` to allow for faster reads. In this PR:
- Added internal cache in front of `fs.readFile`
- Added performance benchmarking
- Added test to verify cache stays sanitized
- Takes down a 3 second test suite to 1 second

Fixes #3.

/cc @mlmorg @Raynos 
