### PR TITLE
Moved to deep clone for `pickMessageInfo`

### DIFF
--- a/lib/connections.js
+++ b/lib/connections.js
@@ -2,6 +2,7 @@ var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var _ = require('underscore');
 var async = require('async');
+var deepClone = require('clone');
 var concat = require('concat-stream');
 
 // Create generic connection to inherit from
@@ -15,7 +16,12 @@ function GenericConnection(req, res) {
 }
 GenericConnection.pickMessageInfo = function (message) {
   // DEV: Refer to http://nodejs.org/api/http.html#http_http_incomingmessage
-  return _.pick(message, 'httpVersion', 'headers', 'trailers', 'method', 'url', 'statusCode');
+  var info = {};
+  // DEV: This is an antipattern where we lose our stack trace
+  ['httpVersion', 'headers', 'trailers', 'method', 'url', 'statusCode'].forEach(function (key) {
+    info[key] = deepClone(message[key]);
+  });
+  return info;
 };
 util.inherits(GenericConnection, EventEmitter);
 

--- a/test/eight-track_test.js
+++ b/test/eight-track_test.js
@@ -495,3 +495,31 @@ describe('A server with redirect being proxied by `eight-track`', function () {
     });
   });
 });
+
+// DEV: This is a regression test for https://github.com/uber/eight-track/issues/21
+describe('A server being proxied by `eight-track` with a noramlizeFn that modifies a deep property', function () {
+  serverUtils.run(1337, function (req, res) {
+    res.send(req.headers);
+  });
+  serverUtils.runEightServer(1338, {
+    fixtureDir: __dirname + '/actual-files/deep-normalize',
+    url: 'http://localhost:1337',
+    normalizeFn: function (info) {
+      info.headers.hai = true;
+      return info;
+    }
+  });
+
+  describe('when requested', function () {
+    httpUtils.save({
+      url: 'http://localhost:1338/',
+      followRedirect: false
+    });
+
+    it('the server does not receive the deep modification', function () {
+      expect(this.err).to.equal(null);
+      expect(this.res.statusCode).to.equal(200);
+      expect(JSON.parse(this.body)).to.not.have.property('hai');
+    });
+  });
+});


### PR DESCRIPTION
As reported in #21, it is not clear and easy to shoot yourself with the current shallow clone from `pickMessageInfo`. This PR moves to a deep clone to prevent accidental updates via `normalizeFn`. In this PR:
- Moved `pickMesageInfo` from shallow clone to deep clone
- Added regression test for #21 

Fixes #21 

/cc @mlmorg @Raynos @zheller 
