### PR TITLE
Added `forwardRequest` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ eightTrack({
 - `multipart/form-data` - Ignore randomly generated boundaries and consolidate similar `multipart/form-data` requests
     - Website: https://github.com/twolfson/eight-track-normalize-multipart
 
+### `eightTrack.forwardRequest(req, cb)`
+Forward an incoming HTTP request in a [`mikeal/request`][]-like format.
+
+- req `http.IncomingMessage` - Inbound request to an HTTP server (e.g. from `http.createServer`)
+    - Documentation: http://nodejs.org/api/http.html#http_http_incomingmessage
+- cb `Function` - Callback function with `(err, res, body)` signature
+    - err `Error` - HTTP error if any occurred (e.g. `ECONNREFUSED`)
+    - res `Object` - Container that looks like an HTTP object but simiplified due to saving to disk
+        - httpVersion `String` - HTTP version received from external server response (e.g. `1.0`, `1.1`)
+        - headers `Object` - Headers received by response
+        - trailers `Object` - Trailers received by response
+        - statusCode `Number` - Status code received from external server response
+        - body `String` - Buffered body that was written to response
+    - body `String` - Sugar variable for `res.body`
+
+[`mikeal/request`]: https://github.com/mikeal/request
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint via [grunt](https://github.com/gruntjs/grunt) and test via `npm test`.
 

--- a/lib/eight-track.js
+++ b/lib/eight-track.js
@@ -101,11 +101,15 @@ EightTrack.prototype = {
     return externalReq;
   },
 
-  handleConnection: function (internalReq, internalRes) {
+  forwardRequest: function (internalReq, callback) {
     // Create a connection to pass around between methods
     // DEV: This cannot be placed inside the waterfall since in 0.8, we miss data + end events
-    var incomingConn = new connections.IncomingConnection(internalReq, internalRes);
+    var incomingConn = new connections.IncomingConnection(internalReq);
     var requestKey, externalConn, connInfo;
+
+    function sendConnInfo(connInfo) {
+      return callback(null, connInfo.response, connInfo.response.body);
+    }
 
     var that = this;
     async.waterfall([
@@ -119,7 +123,7 @@ EightTrack.prototype = {
       function createExternalReq (connInfo, cb) {
         // If we successfully found the info, reply with it
         if (connInfo) {
-          return EightTrack.sendResponse(internalRes, connInfo.response);
+          return sendConnInfo(connInfo);
         }
 
         // Forward the original request to the new server
@@ -139,14 +143,25 @@ EightTrack.prototype = {
           response: externalConn.getResponseInfo()
         };
         that.saveConnection(requestKey, connInfo, cb);
-      },
-      function forwardResponseToOriginal (cb) {
-        EightTrack.sendResponse(internalRes, connInfo.response);
-        cb(null);
       }
-    ], function handleError (err) {
+    ], function handleResponseInfo (err) {
       if (err) {
-        return internalReq.emit('error', err);
+        return callback(err);
+      } else {
+        return sendConnInfo(connInfo);
+      }
+    });
+  },
+
+  handleConnection: function (internalReq, internalRes) {
+    // DEV: externalRes is not request's response but an internal response format
+    this.forwardRequest(internalReq, function handleForwardedResponse (err, externalRes, externalBody) {
+      // If there was an error, emit it
+      if (err) {
+        internalReq.emit('error', err);
+      // Otherwise, send the response
+      } else {
+        EightTrack.sendResponse(internalRes, externalRes);
       }
     });
   }
@@ -160,6 +175,14 @@ function middlewareCreator(options) {
   function eightTrackMiddleware(internalReq, internalRes) {
     eightTrack.handleConnection(internalReq, internalRes);
   }
+
+  // Add on prototype methods (e.g. `forwardRequest`)
+  var keys = Object.getOwnPropertyNames(EightTrack.prototype);
+  keys.forEach(function bindEightTrackMethod (key) {
+    eightTrackMiddleware[key] = function executeEightTrackMethod () {
+      eightTrack[key].apply(eightTrack, arguments);
+    };
+  });
 
   // Return the middleware
   return eightTrackMiddleware;

--- a/test/eight-track_test.js
+++ b/test/eight-track_test.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var expect = require('chai').expect;
 var express = require('express');
 var request = require('request');
+var rimraf = require('rimraf');
 var eightTrack = require('../');
 var httpUtils = require('./utils/http');
 var serverUtils = require('./utils/server');
@@ -302,6 +303,52 @@ describe('An `eight-track` loading from a saved file', function () {
 
     it('does not impact the original data', function () {
       expect(this.res.body).to.equal('oh hai');
+    });
+  });
+});
+
+describe('An `eight-track` with a response modifier', function () {
+  serverUtils.run(1337, function (req, res) {
+    res.send('oh hai', 418);
+  });
+  var fixtureDir =  __dirname + '/actual-files/response-modifier';
+  var _eightTrack = eightTrack({
+    fixtureDir: fixtureDir,
+    url: 'http://localhost:1337'
+  });
+  serverUtils.run(1338, function (req, res) {
+    _eightTrack.forwardRequest(req, function (err, externalRes, externalBody) {
+      res.send(externalBody.replace('hai', 'haiii'), externalRes.statusCode);
+    });
+  });
+  after(function cleanupEightTrack (done) {
+    rimraf(fixtureDir, done);
+  });
+
+
+  describe('receiving a request', function () {
+    httpUtils.save({
+      url: 'http://localhost:1338/'
+    });
+
+    it('responds through our modifier', function () {
+      expect(this.err).to.equal(null);
+      expect(this.res.statusCode).to.equal(418);
+      expect(this.body).to.equal('oh haiii');
+    });
+
+    describe('when requested again', function () {
+      httpUtils.save({
+        url: 'http://localhost:1338/'
+      });
+
+      it('has the same header', function () {
+        expect(this.body).to.equal('oh haiii');
+      });
+
+      it('does not double request', function () {
+        expect(this.requests[1337]).to.have.property('length', 1);
+      });
     });
   });
 });


### PR DESCRIPTION
As discussed in #24, we want to be able to modify response content via a `callback`. In this PR:
- Added `forwardRequest` method to `eightTrack` middlewares
- Added test against `forwardRequest`
- Documented `forwardRequest` method

/cc @zheller @mlmorg @Raynos 
