### PR TITLE
Refactored lib and test to make everything more maintainable

### DIFF
--- a/lib/eight-track.js
+++ b/lib/eight-track.js
@@ -3,9 +3,9 @@ var crypto = require('crypto');
 var url = require('url');
 var _ = require('underscore');
 var async = require('async');
+var Store = require('fs-memory-store');
 var request = require('request');
-var connections = require('./connections');
-var Store = require('./store');
+var Message = require('./message');
 
 function EightTrack(options) {
   // Assert we received the expected options
@@ -13,25 +13,16 @@ function EightTrack(options) {
   assert(options.fixtureDir, '`eight-track` expected `options.fixtureDir` but did not receive it');
 
   // Pre-emptively parse options
-  var externalUrl = options.url;
-  if (typeof externalUrl === 'string') {
-    externalUrl = url.parse(externalUrl);
+  var remoteUrl = options.url;
+  if (typeof remoteUrl === 'string') {
+    remoteUrl = url.parse(remoteUrl);
   }
 
-  // Save externalUrl and fixtureDir for later
-  this.externalUrl = externalUrl;
+  // Save remoteUrl and fixtureDir for later
+  this.remoteUrl = remoteUrl;
   this.normalizeFn = options.normalizeFn || _.identity;
-  this.store = new Store({
-    directory: options.fixtureDir
-  });
+  this.store = new Store(options.fixtureDir);
 }
-
-EightTrack.sendResponse = function (res, info) {
-  res.writeHead(info.statusCode, info.headers);
-  res.write(info.body);
-  res.end();
-};
-
 EightTrack.prototype = {
   getConnectionKey: function (conn) {
     // Generate an object representing the request
@@ -60,16 +51,16 @@ EightTrack.prototype = {
     this.store.set(key, connInfo, cb);
   },
 
-  createExternalRequest: function (internalConn) {
+  createRemoteRequest: function (localReqMsg) {
     // Prepate the URL for headers logic
-    var internalReq = internalConn.req;
-    var internalUrl = url.parse(internalReq.url);
+    var localReq = localReqMsg.connection;
+    var localUrl = url.parse(localReq.url);
     var _url = _.defaults({
-      path: internalUrl.path
-    }, this.externalUrl);
+      path: localUrl.path
+    }, this.remoteUrl);
 
     // Set up headers
-    var headers = internalReq.headers;
+    var headers = localReq.headers;
 
     // If there is a host, use our new host for the request
     if (headers.host) {
@@ -87,25 +78,25 @@ EightTrack.prototype = {
     }
 
     // Forward the original request to the new server
-    var externalReq = request({
+    var remoteReq = request({
       // DEV: Missing `httpVersion`
       headers: headers,
       // DEV: request does not support `trailers`
-      trailers: internalReq.trailers,
-      method: internalReq.method,
+      trailers: localReq.trailers,
+      method: localReq.method,
       url: _url,
-      body: internalConn.body,
+      body: localReqMsg.body,
       // DEV: This is probably an indication that we should no longer use `request`. See #19.
       followRedirect: false
     });
-    return externalReq;
+    return remoteReq;
   },
 
-  forwardRequest: function (internalReq, callback) {
+  forwardRequest: function (localReq, callback) {
     // Create a connection to pass around between methods
     // DEV: This cannot be placed inside the waterfall since in 0.8, we miss data + end events
-    var incomingConn = new connections.IncomingConnection(internalReq);
-    var requestKey, externalConn, connInfo;
+    var localReqMsg = new Message(localReq);
+    var requestKey, remoteResMsg, connInfo;
 
     function sendConnInfo(connInfo) {
       return callback(null, connInfo.response, connInfo.response.body);
@@ -114,33 +105,33 @@ EightTrack.prototype = {
     var that = this;
     async.waterfall([
       function loadIncomingBody (cb) {
-        incomingConn.on('loaded', cb);
+        localReqMsg.on('loaded', cb);
       },
       function findSavedConnection (cb) {
-        requestKey = that.getConnectionKey(incomingConn);
+        requestKey = that.getConnectionKey(localReqMsg);
         that.getConnection(requestKey, cb);
       },
-      function createExternalReq (connInfo, cb) {
+      function createRemoteReq (connInfo, cb) {
         // If we successfully found the info, reply with it
         if (connInfo) {
           return sendConnInfo(connInfo);
         }
 
         // Forward the original request to the new server
-        var externalReq = that.createExternalRequest(incomingConn);
+        var remoteReq = that.createRemoteRequest(localReqMsg);
 
         // When we receive a response, load the response body
-        externalReq.on('error', cb);
-        externalReq.on('response', function handleRes (externalRes) {
-          externalConn = new connections.OutgoingConnection(externalReq, externalRes);
-          externalConn.on('loaded', cb);
+        remoteReq.on('error', cb);
+        remoteReq.on('response', function handleRes (remoteRes) {
+          remoteResMsg = new Message(remoteRes);
+          remoteResMsg.on('loaded', cb);
         });
       },
-      function saveIncomingOutgoing (cb) {
-        // Save the incoming request and outgoing response info
+      function saveIncomingRemote (cb) {
+        // Save the incoming request and remote response info
         connInfo = {
-          request: incomingConn.getRequestInfo(),
-          response: externalConn.getResponseInfo()
+          request: localReqMsg.getRequestInfo(),
+          response: remoteResMsg.getResponseInfo()
         };
         that.saveConnection(requestKey, connInfo, cb);
       }
@@ -153,15 +144,17 @@ EightTrack.prototype = {
     });
   },
 
-  handleConnection: function (internalReq, internalRes) {
-    // DEV: externalRes is not request's response but an internal response format
-    this.forwardRequest(internalReq, function handleForwardedResponse (err, externalRes, externalBody) {
+  handleConnection: function (localReq, localRes) {
+    // DEV: remoteRes is not request's response but an internal response format
+    this.forwardRequest(localReq, function handleForwardedResponse (err, remoteRes, remoteBody) {
       // If there was an error, emit it
       if (err) {
-        internalReq.emit('error', err);
+        localReq.emit('error', err);
       // Otherwise, send the response
       } else {
-        EightTrack.sendResponse(internalRes, externalRes);
+        localRes.writeHead(remoteRes.statusCode, remoteRes.headers);
+        localRes.write(remoteBody);
+        localRes.end();
       }
     });
   }
@@ -172,8 +165,8 @@ function middlewareCreator(options) {
   var eightTrack = new EightTrack(options);
 
   // Define a middleware to handle requests `(req, res)`
-  function eightTrackMiddleware(internalReq, internalRes) {
-    eightTrack.handleConnection(internalReq, internalRes);
+  function eightTrackMiddleware(localReq, localRes) {
+    eightTrack.handleConnection(localReq, localRes);
   }
 
   // Add on prototype methods (e.g. `forwardRequest`)

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,0 +1,53 @@
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+var _ = require('underscore');
+var async = require('async');
+var deepClone = require('clone');
+var concat = require('concat-stream');
+
+// Create connection
+function Message(connection) {
+  // Inherit from event emitter
+  EventEmitter.call(this);
+
+  // Save the connection
+  this.connection = connection;
+
+  // Buffer the content of the connecftion
+  var that = this;
+  connection.pipe(concat(function handleBuffer (buff) {
+    // Save the body and emit a `loaded` event
+    // DEV: The delay is so `async.waterfall` still operates when we enter it
+    that.body = buff.toString();
+    async.setImmediate(function () {
+      that.emit('loaded');
+    });
+  }));
+}
+util.inherits(Message, EventEmitter);
+_.extend(Message.prototype, {
+  pickMessageInfo: function () {
+    // DEV: Refer to http://nodejs.org/api/http.html#http_http_incomingmessage
+    var info = {};
+    // DEV: This is an antipattern where we lose our stack trace
+    ['httpVersion', 'headers', 'trailers', 'method', 'url', 'statusCode'].forEach(function (key) {
+      info[key] = deepClone(this.connection[key]);
+    }, this);
+    return info;
+  },
+  getRequestInfo: function () {
+    var info = this.pickMessageInfo();
+    delete info.statusCode;
+    info.body = this.body;
+    return info;
+  },
+  getResponseInfo: function () {
+    var info = this.pickMessageInfo();
+    delete info.url;
+    delete info.method;
+    info.body = this.body;
+    return info;
+  }
+});
+
+module.exports = Message;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "mkdirp": "~0.3.5",
     "concat-stream": "~1.2.1",
     "async": "~0.2.10",
-    "clone": "~0.1.11"
+    "clone": "~0.1.11",
+    "fs-memory-store": "~0.1.0"
   },
   "devDependencies": {
     "mocha": "~1.11.0",
@@ -44,7 +45,8 @@
     "chai": "~1.8.1",
     "rimraf": "~2.2.5",
     "express": "~3.4.7",
-    "grunt-cli": "~0.1.11"
+    "grunt-cli": "~0.1.11",
+    "request-mocha": "~0.2.0"
   },
   "keywords": [
     "http",

--- a/test/basic_test.js
+++ b/test/basic_test.js
@@ -1,0 +1,91 @@
+var fs = require('fs');
+var expect = require('chai').expect;
+var eightTrack = require('../');
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+describe('A server', function () {
+  serverUtils.run(1337, function (req, res) {
+    res.send('oh hai');
+  });
+
+  describe('being proxied by `eight-track`', function () {
+    var fixtureDir = __dirname + '/actual-files/basic';
+    serverUtils.runEightServer(1338, {
+      fixtureDir: fixtureDir,
+      url: 'http://localhost:1337'
+    });
+
+    describe('when requested once', function () {
+      httpUtils.save('http://localhost:1338/');
+
+      it('touches the server', function () {
+        expect(this.requests[1337]).to.have.property('length', 1);
+      });
+
+      it('receives the expected response', function () {
+        expect(this.err).to.equal(null);
+        expect(this.res.statusCode).to.equal(200);
+        expect(this.body).to.equal('oh hai');
+      });
+
+      it('writes the response to a file', function () {
+        var files = fs.readdirSync(fixtureDir);
+        expect(files).to.have.property('length', 1);
+      });
+
+      describe('and when requested again', function () {
+        httpUtils.save('http://localhost:1338/');
+
+        it('does not touch the server', function () {
+          expect(this.requests[1337]).to.have.property('length', 1);
+        });
+
+        it('receives the expected response', function () {
+          expect(this.err).to.equal(null);
+          expect(this.res.statusCode).to.equal(200);
+          expect(this.body).to.equal('oh hai');
+        });
+      });
+    });
+  });
+});
+
+describe('An `eight-track` loading from a saved file', function () {
+  serverUtils.run(1337, function (req, res) {
+    // DEV: Same length as 'oh hai' for easier development =P
+    res.send('NOOOOO');
+  });
+  serverUtils.run(1338, eightTrack({
+    fixtureDir: __dirname + '/test-files/saved',
+    url: 'http://localhost:1337'
+  }));
+
+  describe('a request to a canned response', function () {
+    httpUtils.save({
+      url: 'http://localhost:1338/'
+    });
+
+    it('uses the saved response', function () {
+      expect(this.err).to.equal(null);
+      expect(this.body).to.equal('oh hai');
+    });
+  });
+
+  // DEV: This is a test for verifying we don't contaminate our cache
+  describe('when a response is modified', function () {
+    httpUtils.save({
+      url: 'http://localhost:1338/'
+    });
+    before(function () {
+      this.res.body = 'hello';
+    });
+    httpUtils.save({
+      url: 'http://localhost:1338/'
+    });
+
+    it('does not impact the original data', function () {
+      expect(this.res.body).to.equal('oh hai');
+    });
+  });
+});

--- a/test/deep-normalize_test.js
+++ b/test/deep-normalize_test.js
@@ -1,0 +1,31 @@
+var expect = require('chai').expect;
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+// DEV: This is a regression test for https://github.com/uber/eight-track/issues/21
+describe('A server being proxied by `eight-track` with a noramlizeFn that modifies a deep property', function () {
+  serverUtils.run(1337, function (req, res) {
+    res.send(req.headers);
+  });
+  serverUtils.runEightServer(1338, {
+    fixtureDir: __dirname + '/actual-files/deep-normalize',
+    url: 'http://localhost:1337',
+    normalizeFn: function (info) {
+      info.headers.hai = true;
+      return info;
+    }
+  });
+
+  describe('when requested', function () {
+    httpUtils.save({
+      url: 'http://localhost:1338/',
+      followRedirect: false
+    });
+
+    it('the server does not receive the deep modification', function () {
+      expect(this.err).to.equal(null);
+      expect(this.res.statusCode).to.equal(200);
+      expect(JSON.parse(this.body)).to.not.have.property('hai');
+    });
+  });
+});

--- a/test/enametoolong_test.js
+++ b/test/enametoolong_test.js
@@ -1,0 +1,27 @@
+var expect = require('chai').expect;
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+// DEV: This is a regression test for https://github.com/uber/eight-track/issues/7
+describe('A server being proxied by `eight-track', function () {
+  serverUtils.run(1337, function (req, res) {
+    res.send('oh hai');
+  });
+  serverUtils.runEightServer(1338, {
+    fixtureDir: __dirname + '/actual-files/basic',
+    url: 'http://localhost:1337'
+  });
+
+  describe('when requested with a very long URL', function () {
+    var lotsOfCharacters = (new Array(9001)).join('a');
+    httpUtils.save('http://localhost:1338/abc/' + lotsOfCharacters + '/def');
+
+    describe('and when requested with a slightly different long URL', function () {
+      httpUtils.save('http://localhost:1338/abc/' + lotsOfCharacters + '/deg');
+
+      it('recognizes it as a separate response', function () {
+        expect(this.requests[1337]).to.have.property('length', 2);
+      });
+    });
+  });
+});

--- a/test/forward-request_test.js
+++ b/test/forward-request_test.js
@@ -1,0 +1,51 @@
+var expect = require('chai').expect;
+var rimraf = require('rimraf');
+var eightTrack = require('../');
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+describe('An `eight-track` with a response modifier', function () {
+  serverUtils.run(1337, function (req, res) {
+    res.send('oh hai', 418);
+  });
+  var fixtureDir =  __dirname + '/actual-files/response-modifier';
+  var _eightTrack = eightTrack({
+    fixtureDir: fixtureDir,
+    url: 'http://localhost:1337'
+  });
+  serverUtils.run(1338, function (req, res) {
+    _eightTrack.forwardRequest(req, function (err, remoteRes, remoteBody) {
+      res.send(remoteBody.replace('hai', 'haiii'), remoteRes.statusCode);
+    });
+  });
+  after(function cleanupEightTrack (done) {
+    rimraf(fixtureDir, done);
+  });
+
+
+  describe('receiving a request', function () {
+    httpUtils.save({
+      url: 'http://localhost:1338/'
+    });
+
+    it('responds through our modifier', function () {
+      expect(this.err).to.equal(null);
+      expect(this.res.statusCode).to.equal(418);
+      expect(this.body).to.equal('oh haiii');
+    });
+
+    describe('when requested again', function () {
+      httpUtils.save({
+        url: 'http://localhost:1338/'
+      });
+
+      it('has the same header', function () {
+        expect(this.body).to.equal('oh haiii');
+      });
+
+      it('does not double request', function () {
+        expect(this.requests[1337]).to.have.property('length', 1);
+      });
+    });
+  });
+});

--- a/test/headers_test.js
+++ b/test/headers_test.js
@@ -1,0 +1,60 @@
+var expect = require('chai').expect;
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+describe('A server that echoes HTTP headers', function () {
+  serverUtils.run(1337, function (req, res) {
+    res.send(req.headers);
+  });
+  serverUtils.runEightServer(1338, {
+    fixtureDir: __dirname + '/actual-files/headers',
+    url: 'http://localhost:1337'
+  });
+
+  describe('when requested with a special header', function () {
+    httpUtils.save({
+      headers: {
+        'x-hai': 'world'
+      },
+      url: 'http://localhost:1338/'
+    });
+
+    it('replies with a our header', function () {
+      expect(this.err).to.equal(null);
+      expect(this.res.statusCode).to.equal(200);
+      expect(JSON.parse(this.body)).to.have.property('x-hai', 'world');
+    });
+
+    describe('when requested again', function () {
+      httpUtils.save({
+        headers: {
+          'x-hai': 'world'
+        },
+        url: 'http://localhost:1338/'
+      });
+
+      it('has the same header', function () {
+        expect(JSON.parse(this.body)).to.have.property('x-hai', 'world');
+      });
+
+      it('does not double request', function () {
+        expect(this.requests[1337]).to.have.property('length', 1);
+      });
+    });
+
+    describe('and a request with a different set of headers', function () {
+      httpUtils.save({
+        headers: {
+          'x-goodbye': 'moon'
+        },
+        url: 'http://localhost:1338/'
+      });
+
+      it('receives a different set of parameters', function () {
+        expect(this.err).to.equal(null);
+        expect(JSON.parse(this.body)).to.have.property('x-goodbye', 'moon');
+      });
+    });
+
+  });
+});

--- a/test/host-header_test.js
+++ b/test/host-header_test.js
@@ -1,0 +1,54 @@
+var expect = require('chai').expect;
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+// DEV: Regression test for https://github.com/uber/eight-track/issues/4
+describe('A server that echoes HTTP headers', function () {
+  serverUtils.run(1337, function (req, res) {
+    res.send(req.headers);
+  });
+  serverUtils.runEightServer(1338, {
+    fixtureDir: __dirname + '/actual-files/headers',
+    url: 'http://localhost:1337'
+  });
+
+  describe('when requested with a `Host` header', function () {
+    httpUtils.save({
+      headers: {
+        host: '127.0.0.1:9001'
+      },
+      url: 'http://localhost:1338/'
+    });
+
+    it('replies with a proper `Host` header', function () {
+      expect(this.err).to.equal(null);
+      expect(this.res.statusCode).to.equal(200);
+      expect(JSON.parse(this.body)).to.have.property('host', 'localhost:1337');
+    });
+
+    it('does not affect the original header', function () {
+      expect(this.res.req._headers).to.have.property('host', '127.0.0.1:9001');
+    });
+
+    describe('when requested again', function () {
+      httpUtils.save({
+        headers: {
+          host: '127.0.0.1:9001'
+        },
+        url: 'http://localhost:1338/'
+      });
+
+      it('has the proper `Host` header', function () {
+        expect(JSON.parse(this.body)).to.have.property('host', 'localhost:1337');
+      });
+
+      it('does not affect the original header', function () {
+        expect(this.res.req._headers).to.have.property('host', '127.0.0.1:9001');
+      });
+
+      it('does not double request', function () {
+        expect(this.requests[1337]).to.have.property('length', 1);
+      });
+    });
+  });
+});

--- a/test/method_test.js
+++ b/test/method_test.js
@@ -1,0 +1,55 @@
+var expect = require('chai').expect;
+var express = require('express');
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+describe('A server that echoes method that is being proxied', function () {
+  serverUtils.run(1337, function (req, res) {
+    express.urlencoded()(req, res, function (err) {
+      if (err) { throw err; }
+      res.send({
+        method: req.method,
+        body: req.body
+      });
+    });
+  });
+  serverUtils.runEightServer(1338, {
+    fixtureDir: __dirname + '/actual-files/method',
+    url: 'http://localhost:1337'
+  });
+
+  describe('when requested via POST', function () {
+    httpUtils.save({
+      method: 'POST',
+      url: 'http://localhost:1338/',
+      form: {
+        hello: 'world'
+      }
+    });
+
+    it('replies with POST', function () {
+      expect(this.err).to.equal(null);
+      expect(this.res.statusCode).to.equal(200);
+      expect(JSON.parse(this.body)).to.deep.equal({
+        method: 'POST',
+        body: {
+          hello: 'world'
+        }
+      });
+    });
+
+    describe('when requested again', function () {
+      httpUtils.save({
+        method: 'POST',
+        url: 'http://localhost:1338/',
+        form: {
+          hello: 'world'
+        }
+      });
+
+      it('does not double request', function () {
+        expect(this.requests[1337]).to.have.property('length', 1);
+      });
+    });
+  });
+});

--- a/test/normalize-fn_test.js
+++ b/test/normalize-fn_test.js
@@ -1,0 +1,61 @@
+var expect = require('chai').expect;
+var express = require('express');
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+describe('A server with distinct responses', function () {
+  serverUtils.run(1337, function (req, res) {
+    express.urlencoded()(req, res, function (err) {
+      if (err) { throw err; }
+      res.send({
+        method: req.method,
+        url: req.url
+      });
+    });
+  });
+
+  describe('proxied by an eight-track that normalizes everything', function () {
+    serverUtils.runEightServer(1338, {
+      fixtureDir: __dirname + '/actual-files/headers',
+      url: 'http://localhost:1337',
+      normalizeFn: function (info) {
+        return {
+          url: '/',
+          method: 'GET'
+        };
+      }
+    });
+
+    describe('when requested', function () {
+      httpUtils.save('http://localhost:1338/?hello=there');
+
+      it('gets the expected response', function () {
+        expect(this.err).to.equal(null);
+        expect(JSON.parse(this.body)).to.deep.equal({
+          method: 'GET',
+          url: '/?hello=there'
+        });
+      });
+
+      describe('when requested with something different', function () {
+        httpUtils.save({
+          url: 'http://localhost:1338/wat',
+          method: 'POST',
+          body: 'goodbye=moon'
+        });
+
+        it('gets the original response back', function () {
+          expect(this.err).to.equal(null);
+          expect(JSON.parse(this.body)).to.deep.equal({
+            method: 'GET',
+            url: '/?hello=there'
+          });
+        });
+
+        it('does not touch the server', function () {
+          expect(this.requests[1337]).to.have.property('length', 1);
+        });
+      });
+    });
+  });
+});

--- a/test/path_test.js
+++ b/test/path_test.js
@@ -1,0 +1,39 @@
+var expect = require('chai').expect;
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+// DEV: This is testing uniquely generated keys
+describe('A server with multiple paths', function () {
+  serverUtils.run(1337, function (req, res) {
+    if (req.url === '/hello') {
+      res.send('hello');
+    } else {
+      res.send('world');
+    }
+  });
+
+  describe('being proxied by `eight-track`', function () {
+    serverUtils.runEightServer(1338, {
+      fixtureDir: __dirname + '/actual-files/multi',
+      url: 'http://localhost:1337'
+    });
+
+    describe('a request to `/hello`', function () {
+      httpUtils.save('http://localhost:1338/hello');
+
+      it('replies with \'hello\'', function () {
+        expect(this.err).to.equal(null);
+        expect(this.body).to.equal('hello');
+      });
+
+      describe('and a request to `/world`', function () {
+        httpUtils.save('http://localhost:1338/world');
+
+        it('replies with \'world\'', function () {
+          expect(this.err).to.equal(null);
+          expect(this.body).to.equal('world');
+        });
+      });
+    });
+  });
+});

--- a/test/querystring_test.js
+++ b/test/querystring_test.js
@@ -1,0 +1,41 @@
+var expect = require('chai').expect;
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+// DEV: This tests that we save a request with query parameters
+// DEV: and that it forwards the query parameters
+describe('A query-echoing server being proxied', function () {
+  serverUtils.run(1337, function (req, res) {
+    res.send(req.query);
+  });
+  serverUtils.runEightServer(1338, {
+    fixtureDir: __dirname + '/actual-files/query',
+    url: 'http://localhost:1337'
+  });
+
+  describe('when requested with one set of query parameters', function () {
+    httpUtils.save('http://localhost:1338/?hello=world');
+
+    it('receives with its query parameters', function () {
+      expect(this.err).to.equal(null);
+      expect(JSON.parse(this.body)).to.deep.equal({hello:'world'});
+    });
+
+    describe('when requested again', function () {
+      httpUtils.save('http://localhost:1338/?hello=world');
+
+      it('does not double request', function () {
+        expect(this.requests[1337]).to.have.property('length', 1);
+      });
+    });
+
+    describe('and a request with a different set of query parameters', function () {
+      httpUtils.save('http://localhost:1338/?goodbye=moon');
+
+      it('receives a different set of parameters', function () {
+        expect(this.err).to.equal(null);
+        expect(JSON.parse(this.body)).to.deep.equal({goodbye:'moon'});
+      });
+    });
+  });
+});

--- a/test/redirect_test.js
+++ b/test/redirect_test.js
@@ -1,0 +1,61 @@
+var expect = require('chai').expect;
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+// DEV: This is a regression test for https://github.com/uber/eight-track/issues/18
+describe('A server with redirect being proxied by `eight-track`', function () {
+  serverUtils.run(1337, function (req, res) {
+    if (req.url === '/') {
+      res.redirect('/main');
+    } else {
+      res.send('oh hai');
+    }
+  });
+  serverUtils.runEightServer(1338, {
+    fixtureDir: __dirname + '/actual-files/redirect',
+    url: 'http://localhost:1337'
+  });
+
+  describe('when a redirect route is requested', function () {
+    httpUtils.save({
+      url: 'http://localhost:1338/',
+      followRedirect: false
+    });
+
+    it('replies with redirect information', function () {
+      expect(this.err).to.equal(null);
+      expect(this.res.statusCode).to.equal(302);
+      expect(this.res.headers).to.have.property('location', '/main');
+    });
+
+    describe('when the rediect route is requested again', function () {
+      httpUtils.save({
+        url: 'http://localhost:1338/',
+        followRedirect: false
+      });
+
+      it('replies with redirect information', function () {
+        expect(this.err).to.equal(null);
+        expect(this.res.statusCode).to.equal(302);
+        expect(this.res.headers).to.have.property('location', '/main');
+      });
+
+      it('does not double request', function () {
+        expect(this.requests[1337]).to.have.property('length', 1);
+      });
+    });
+
+    describe('when the route is requested and follows redirects', function () {
+      httpUtils.save({
+        url: 'http://localhost:1338/'
+      });
+
+      it('receives main\'s content', function () {
+        expect(this.err).to.equal(null);
+        expect(this.res.statusCode).to.equal(200);
+        expect(this.res.req).to.have.property('path', '/main');
+        expect(this.body).to.equal('oh hai');
+      });
+    });
+  });
+});

--- a/test/status-code_test.js
+++ b/test/status-code_test.js
@@ -1,0 +1,35 @@
+var expect = require('chai').expect;
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+describe('A failing server that is being proxied', function () {
+  serverUtils.run(1337, function (req, res) {
+    res.send('error', 500);
+  });
+  serverUtils.runEightServer(1338, {
+    fixtureDir: __dirname + '/actual-files/status',
+    url: 'http://localhost:1337'
+  });
+
+  describe('when requested', function () {
+    httpUtils.save('http://localhost:1338/');
+
+    it('replies with a 500 status code and its message', function () {
+      expect(this.err).to.equal(null);
+      expect(this.res.statusCode).to.equal(500);
+      expect(this.body).to.equal('error');
+    });
+
+    describe('when requested again', function () {
+      httpUtils.save('http://localhost:1338/');
+
+      it('has the same status code', function () {
+        expect(this.res.statusCode).to.equal(500);
+      });
+
+      it('does not double request', function () {
+        expect(this.requests[1337]).to.have.property('length', 1);
+      });
+    });
+  });
+});

--- a/test/utils/http.js
+++ b/test/utils/http.js
@@ -1,20 +1,6 @@
 // Load in dependencies
 var request = require('request');
+var requestMocha = require('request-mocha');
 
 // Helper for mocha to save request information
-exports._save = function (options) {
-  // Request to the URL and save results to `this` context
-  return function _saveFn (done) {
-    var that = this;
-    request(options, function (err, res, body) {
-      that.err = err;
-      that.res = res;
-      that.body = body;
-      done();
-    });
-  };
-};
-
-exports.save = function (options) {
-  before(exports._save(options));
-};
+module.exports = requestMocha(request);


### PR DESCRIPTION
**Minor release**

I began working on fixing #17 but got frustrated at the growth that `eight-track` has turned into. In order to get a hold on things, I have performed the following:
- Removed `lib/store` and created https://github.com/twolfson/fs-memory-store
- Consolidated `Connections` into `Message` class (they all feel the same)
- Relocate premature class method abstractions onto prototypes (e.g. `Message.getResponseInfo`)
- Broke down 500+ line test file into many separate files
- Swapped out `test/utils/http` for `request-mocha`

/cc @mlmorg @zheller @Raynos 
