### PR TITLE
Allow subpaths for proxy URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,26 @@ Forward an incoming HTTP request in a [`mikeal/request`][]-like format.
 
 [`mikeal/request`]: https://github.com/mikeal/request
 
+## Examples
+### Proxy server with subpath
+`eight-track` can talk to servers that are behind a specific path
+
+```js
+// Start up a server that echoes our path
+express().use(function (req, res) {
+  res.send(req.path);
+}).listen(1337);
+
+// Create a server using a `eight-track` middleware to the original
+express().use(eightTrack({
+  url: 'http://localhost:1337/hello',
+  fixtureDir: 'directory/to/save/responses'
+})).listen(1338);
+
+// Logs `/hello/world`, concatenated result of `/hello` and `/world` pathss
+request('http://localhost:1338/world', console.log);
+```
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint via [grunt](https://github.com/gruntjs/grunt) and test via `npm test`.
 

--- a/docs/example-subpath.js
+++ b/docs/example-subpath.js
@@ -1,0 +1,16 @@
+// Start up a server that echoes our path
+var express = require('express');
+var eightTrack = require('../');
+var request = require('request');
+express().use(function (req, res) {
+  res.send(req.path);
+}).listen(1337);
+
+// Create a server using a `eight-track` middleware to the original
+express().use(eightTrack({
+  url: 'http://localhost:1337/hello',
+  fixtureDir: 'directory/to/save/responses'
+})).listen(1338);
+
+// Logs `/hello/world`, concatenated result of `/hello` and `/world` pathss
+request('http://localhost:1338/world', console.log);

--- a/lib/eight-track.js
+++ b/lib/eight-track.js
@@ -93,11 +93,29 @@ EightTrack.prototype = {
 
   createRemoteRequest: function (localReqMsg) {
     // Prepate the URL for headers logic
+    // TODO: It feels like URL extension deserves to be its own node module
+    // http://nodejs.org/api/url.html#url_url
+    /*
+      headers: local (+ remote host)
+      protocol: remote,
+      hostname: remote,
+      port: remote,
+      pathname: remote + local, (e.g. /abc + /def -> /abc/def)
+      query: local
+    */
     var localReq = localReqMsg.connection;
     var localUrl = url.parse(localReq.url);
-    var _url = _.defaults({
-      path: localUrl.path
-    }, this.remoteUrl);
+    var _url = _.pick(this.remoteUrl, 'protocol', 'hostname', 'port');
+
+    // If the remotePathname is a `/`, convert it to a ''. Node decides that all URLs deserve a `pathname` even when not provided
+    var remotePathname = this.remoteUrl.pathname || '';
+    if (remotePathname === '/') {
+      remotePathname = '';
+    }
+
+    // DEV: We use string concatenation because we cannot predict how all servers are designed
+    _url.pathname = remotePathname + (localUrl.pathname || '');
+    _url.search = localUrl.query;
 
     // Set up headers
     var headers = localReq.headers;
@@ -124,7 +142,7 @@ EightTrack.prototype = {
       // DEV: request does not support `trailers`
       trailers: localReq.trailers,
       method: localReq.method,
-      url: _url,
+      url: url.format(_url),
       body: localReqMsg.body,
       // DEV: This is probably an indication that we should no longer use `request`. See #19.
       followRedirect: false

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "rimraf": "~2.2.5",
     "express": "~3.4.7",
     "grunt-cli": "~0.1.11",
-    "request-mocha": "~0.2.0"
+    "request-mocha": "~0.2.0",
+    "pem": "~1.4.0"
   },
   "keywords": [
     "http",

--- a/test/url_test.js
+++ b/test/url_test.js
@@ -1,0 +1,45 @@
+var expect = require('chai').expect;
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+describe('An `eight-track` server proxying a subpath', function () {
+  serverUtils.run(1337, function (req, res) {
+    res.send(req.url);
+  });
+  serverUtils.runEightServer(1338, {
+    fixtureDir: __dirname + '/actual-files/redirect',
+    url: 'http://localhost:1337/hello'
+  });
+
+  describe('when requested with a path', function () {
+    httpUtils.save('http://localhost:1338/world');
+
+    it('concatenates the path', function () {
+      expect(this.err).to.equal(null);
+      expect(this.body).to.equal('/hello/world');
+    });
+  });
+});
+
+describe('An `eight-track` server proxying an HTTPS server', function () {
+  serverUtils.runHttps(1337, function (req, res) {
+    res.send('oh hai');
+  });
+  serverUtils.runEightServer(1338, {
+    fixtureDir: __dirname + '/actual-files/redirect',
+    url: 'https://localhost:1337/'
+  });
+
+  describe('when requested', function () {
+    before(function allowSelfSignedCert () {
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    });
+    httpUtils.save('http://localhost:1338/');
+
+    it('proxies to the server', function () {
+      expect(this.err).to.equal(null);
+      expect(this.res.statusCode).to.equal(200);
+      expect(this.body).to.equal('oh hai');
+    });
+  });
+});


### PR DESCRIPTION
Sometimes proxies need to point to concatenated paths (e.g. `/hello` + `/world` -> `/hello/world`). In this PR:
- Add test for concatenated paths
- Implement path concatenation in `eight-track

Fixes #2 

/cc @mlmorg @zheller @Raynos
