### PR TITLE
Added ability for requests to already be buffered

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ eightTrack({
 });
 ```
 
+If you need to buffer the data before passing it off to `eight-track` that is supported as well.
+The requirement is that you record the data as a `Buffer` or `String` to `req.body`.
+
 #### `normalizeFn` libraries
 - `multipart/form-data` - Ignore randomly generated boundaries and consolidate similar `multipart/form-data` requests
     - Website: https://github.com/twolfson/eight-track-normalize-multipart

--- a/lib/eight-track.js
+++ b/lib/eight-track.js
@@ -160,9 +160,18 @@ EightTrack.prototype = {
       return callback(null, connInfo.response, connInfo.response.body);
     }
 
+    // Create marker for request loading before we get to `loadIncomingBody` listener
+    var localReqLoaded = false;
+    localReqMsg.on('loaded', function updateLoadedState () {
+      localReqLoaded = true;
+    });
+
     var that = this;
     async.waterfall([
       function loadIncomingBody (cb) {
+        if (localReqLoaded) {
+          return process.nextTick(cb);
+        }
         localReqMsg.on('loaded', cb);
       },
       function findSavedConnection (cb) {
@@ -241,6 +250,7 @@ function middlewareCreator(options) {
 
 // Expose class on top of middlewareCreator
 middlewareCreator.EightTrack = EightTrack;
+middlewareCreator.Message = Message;
 
 // Expose our middleware constructor
 module.exports = middlewareCreator;

--- a/lib/message.js
+++ b/lib/message.js
@@ -8,13 +8,22 @@ var concat = require('concat-stream');
 // Create connection
 function Message(connection) {
   // Inherit from event emitter
+  var that = this;
   EventEmitter.call(this);
 
   // Save the connection
   this.connection = connection;
 
+  // If there is a body already, don't buffer
+  if (connection.body) {
+    that.body = connection.body;
+    async.setImmediate(function () {
+      that.emit('loaded');
+    });
+    return;
+  }
+
   // Buffer the content of the connecftion
-  var that = this;
   connection.pipe(concat(function handleBuffer (buff) {
     // Save the body and emit a `loaded` event
     // DEV: The delay is so `async.waterfall` still operates when we enter it

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "express": "~3.4.7",
     "grunt-cli": "~0.1.11",
     "request-mocha": "~0.2.0",
-    "pem": "~1.4.0"
+    "pem": "~1.4.0",
+    "raw-body": "~1.1.5"
   },
   "keywords": [
     "http",

--- a/test/buffered-body_test.js
+++ b/test/buffered-body_test.js
@@ -1,0 +1,70 @@
+var expect = require('chai').expect;
+var express = require('express');
+var rawBody = require('raw-body');
+var eightTrack = require('../');
+var httpUtils = require('./utils/http');
+var serverUtils = require('./utils/server');
+
+// TODO: This should be a separate repo
+function connectRawBody(req, res, next) {
+  rawBody(req, function handleBody (err, buff) {
+    if (err) {
+      next(err);
+    }
+    req.body = buff;
+    next();
+  });
+}
+
+describe('A server that asserts content before talking to eight-track', function () {
+  serverUtils.run(1337, [
+    express.urlencoded(),
+    function (req, res) {
+      res.send(req.body);
+    }
+  ]);
+  serverUtils.run(1338, [
+    connectRawBody,
+    function assertInfo (req, res, next) {
+      expect(req.body.toString()).to.equal('hello=world');
+      next();
+    },
+    eightTrack({
+      fixtureDir: __dirname + '/actual-files/buffered-body',
+      url: 'http://localhost:1337'
+    })
+  ]);
+  serverUtils._cleanupEightTrack(__dirname + '/actual-files/buffered-body');
+
+  describe('when requested', function () {
+    httpUtils.save({
+      form: {
+        hello: 'world'
+      },
+      url: 'http://localhost:1338/'
+    });
+
+    it('replies with a our header', function () {
+      expect(this.err).to.equal(null);
+      expect(this.res.statusCode).to.equal(200);
+      expect(JSON.parse(this.body)).to.have.property('hello', 'world');
+    });
+
+    describe('when requested again', function () {
+      httpUtils.save({
+        form: {
+          hello: 'world'
+        },
+        url: 'http://localhost:1338/'
+      });
+
+      it('has the same header', function () {
+        expect(JSON.parse(this.body)).to.have.property('hello', 'world');
+      });
+
+      it('does not double request', function () {
+        expect(this.requests[1337]).to.have.property('length', 1);
+      });
+    });
+  });
+});

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -24,7 +24,12 @@ exports._run = function (listenFn, port, middlewares) {
     });
 
     // Use our middlewares and start listening
-    app.use(middlewares);
+    if (!Array.isArray(middlewares)) {
+      middlewares = [middlewares];
+    }
+    middlewares.forEach(function (middleware) {
+      app.use(middleware);
+    });
     _app = listenFn(app, port);
   });
   after(function deleteServer (done) {
@@ -63,9 +68,12 @@ exports.runHttps = function (port, middlewares) {
 };
 
 // Start an eight-track server
+exports._cleanupEightTrack = function (fixtureDir) {
+  after(function cleanupEightTrack (done) {
+    rimraf(fixtureDir, done);
+  });
+};
 exports.runEightServer = function (port, options) {
   exports.run(port, eightTrack(options));
-  after(function cleanupEightTrack (done) {
-    rimraf(options.fixtureDir, done);
-  });
+  exports._cleanupEightTrack(options.fixtureDir);
 };


### PR DESCRIPTION
As mentioned in #32, it would be practical to allow to pass in requests after they have already been buffered. This allows for assertions when it is hard to establish playback state.

I explored `forwardBufferedRequest(localReq, localBuff, callback)` but that yielded a more complex interface (especially for middleware chains) so I decided to scrap it.

In this PR:
- Add the ability for `req.body` to be the already-defined body
- Added test against `req.body`
- Added documentation

/cc @Raynos @mlmorg
