### PR TITLE
Added fork notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ This is built to make testing against third party services a breeze. No longer w
 [`cassette`]: https://github.com/uber/cassette
 [`vcr`]: https://rubygems.org/gems/vcr
 
+## Active forks
+`eight-track` has been forked by [@twolfson][] as [`nine-track`][]. This includes new features such as `scrubFn` for sanitizing data before saving to disk.
+
+[@twolfson]: https://github.com/twolfson
+[`nine-track`]: https://github.com/twolfson/nine-track
+
 ## Getting Started
 Install the module with: `npm install eight-track`
 


### PR DESCRIPTION
I have forked `eight-track` to a repo named `nine-track`. I was unable to gain `push` permissions for `eight-track`. I believe this will cause awkward and inefficient workflows as it has in Uber/sublime-phabricator#7. As a result, I have decided to fork out of frustration.

https://github.com/twolfson/nine-track

I have a few features planned for the fork:

- Allow data to be sanitized before saving to disk
    - Useful for scrubbing authentication info on public repos
- Handle series-based requests (e.g. make a read, submit an update, read again to verify changes)
    - Early notes: https://gist.github.com/twolfson/f8848600a71884ee107d

In this PR:

- Added list of active forks to `README`